### PR TITLE
Replace depedency text with right format

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Add to your dependencies:
 
 ```groovy
 dependencies {
-    compile 'com.github.hendrixstring:Android-PdfMyXml:{version}'
+    compile 'com.github.HendrixString:Android-PdfMyXml:{Tag}' // the latest version is "v1.0.1"
 }
 ```
 


### PR DESCRIPTION
According to JitPack.io, dependency format need to be `compile 'com.github.User:Repo:Tag'`. So, the correct format for current one should be `compile 'com.github.HendrixString:Android-PdfMyXml:v1.0.1'`. That's why I've fixed the example in Readme.md.
