### PR TITLE
Update Aspect Ratio Calculation on Images

### DIFF
--- a/lib/src/main/java/com/hendrix/pdfmyxml/PdfDocument.java
+++ b/lib/src/main/java/com/hendrix/pdfmyxml/PdfDocument.java
@@ -376,7 +376,14 @@ public class PdfDocument implements IDisposable{
 
                 inputStream.close(); //doesn't do anything in byte array
 
-                ar                  = page.getWidth() / image.getWidth();
+                float i_width = image.getWidth();
+                float i_height = image.getHeight();
+
+                if(i_width > i_height){
+                    ar = page.getWidth() / i_width;
+                }else {
+                    ar = page.getHeight() / i_height;
+                }
 
                 image.scaleBy(ar);
 


### PR DESCRIPTION
I have updated the aspect ratio calculation method from 

`ar = page.getWidth() / image.getWidth();`

to
```
float i_width = image.getWidth();
float i_height = image.getHeight();

if(i_width > i_height){
    ar = page.getWidth() / i_width;
 }else {
    ar = page.getHeight() / i_height;
}
```
because if image height is greater than the width the updated method gives correct aspect ratio. Otherwise previous aspect ratio will give the value to fit in to width in every scenarios.